### PR TITLE
Updated API references

### DIFF
--- a/populate_database.py
+++ b/populate_database.py
@@ -1,11 +1,11 @@
 import argparse
 import os
 import shutil
-from langchain.document_loaders.pdf import PyPDFDirectoryLoader
+from langchain_community.document_loaders import PyPDFDirectoryLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain.schema.document import Document
 from get_embedding_function import get_embedding_function
-from langchain.vectorstores.chroma import Chroma
+from langchain_chroma.vectorstores import Chroma
 
 
 CHROMA_PATH = "chroma"
@@ -67,7 +67,7 @@ def add_to_chroma(chunks: list[Document]):
         print(f"👉 Adding new documents: {len(new_chunks)}")
         new_chunk_ids = [chunk.metadata["id"] for chunk in new_chunks]
         db.add_documents(new_chunks, ids=new_chunk_ids)
-        db.persist()
+        db.persist() #no longer required to persist explicitly
     else:
         print("✅ No new documents to add")
 


### PR DESCRIPTION
The updates made in the script - 
1. langchain-chroma reference module updated
2. langchain.document_loaders module updated
3. Added a comment to point out that the persist() function is no longer required by Chroma.